### PR TITLE
sepolicy: add file and domain trans to interfacer

### DIFF
--- a/themeinterfacer.te
+++ b/themeinterfacer.te
@@ -61,3 +61,8 @@ allow themeinterfacer display_service:service_manager find;
 allow themeinterfacer mount_service:service_manager find;
 allow themeinterfacer network_management_service:service_manager find;
 allow themeinterfacer overlay_service:service_manager find;
+
+# Allow file and type transition for contexts
+type_transition interfacer system_data_file:file theme_data_file "theme";
+type_transition interfacer system_data_file:dir theme_data_file;
+file_type_auto_trans(interfacer, system_data_file, theme_data_file);

--- a/untrusted_app.te
+++ b/untrusted_app.te
@@ -216,3 +216,4 @@ neverallow untrusted_app tun_device:chr_file open;
 # Only allow appending to /data/anr/traces.txt (b/27853304, b/18340553)
 neverallow untrusted_app anr_data_file:file ~{ open append };
 neverallow untrusted_app anr_data_file:dir ~search;
+allow untrusted_app system_app_data_file:dir getattr;


### PR DESCRIPTION
This will fix bootanimations not applying on 7.1.2 ROMs

Change-Id: I3dd752dcb58ee84ac9953252a1fb3c5cd84c90c7